### PR TITLE
Use github-markdown-css for project info view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdi/font": "7.0.96",
         "core-js": "^3.29.0",
+        "github-markdown-css": "^5.7.0",
         "highlight.js": "^11.9.0",
         "marked": "^9.1.5",
         "marked-base-url": "^1.1.0",
@@ -1731,6 +1732,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/github-markdown-css": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.7.0.tgz",
+      "integrity": "sha512-GoYhaqELL4YUjz4tZ00PQ4JzFQkMfrBVuEeRB8W74HoikHWNiaGqSgynpwJEc+xom5uf04qoD/tUSS6ziZltaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdi/font": "7.0.96",
     "core-js": "^3.29.0",
+    "github-markdown-css": "^5.7.0",
     "highlight.js": "^11.9.0",
     "marked": "^9.1.5",
     "marked-base-url": "^1.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {markedHighlight} from "marked-highlight";
 import * as hljs from "highlight.js";
 
 import 'highlight.js/styles/github-dark.css';
+import 'github-markdown-css';
 import '@/styles/style.css';
 
 import {baseUrl} from "marked-base-url";

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -13,3 +13,21 @@
 .noSelect:focus {
     outline: none !important;
 }
+
+/* From https://github.com/sindresorhus/github-markdown-css */
+.markdown-body {
+    box-sizing: border-box;
+    min-width: 200px;
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 45px 0;
+
+    /* Change the background color to nothing */
+    --bgColor-default: none;
+}
+
+@media (max-width: 767px) {
+    .markdown-body {
+        padding: 15px 0;
+    }
+}

--- a/src/views/ProjectInfoView.vue
+++ b/src/views/ProjectInfoView.vue
@@ -101,7 +101,7 @@
 
       <v-divider/>
 
-      <div v-html="markdownToHtml" style="text-align: start"/>
+      <div class="markdown-body" v-html="markdownToHtml" style="text-align: start"/>
 
       <v-divider/>
       <div class="py-2"/>


### PR DESCRIPTION
This PR resolves #3 by using https://github.com/sindresorhus/github-markdown-css to apply GitHub-flavored markdown styling to the project information view (i.e., the README). See the linked issue for the comparison before and after this PR.