### PR TITLE
Fix light mode appearance of project info view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import {markedHighlight} from "marked-highlight";
 import * as hljs from "highlight.js";
 
 import 'highlight.js/styles/github-dark.css';
-import 'github-markdown-css';
+import 'github-markdown-css/github-markdown-dark.css';
 import '@/styles/style.css';
 
 import {baseUrl} from "marked-base-url";

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -24,6 +24,7 @@
 
     /* Change the background color to nothing */
     --bgColor-default: none;
+    background-color: transparent;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
This PR fixes an issue reported through Discord by a user named darkere, where a system/browser-set light theme would cause the text on the project view to become unreadable (black text on dark background), by changing the GitHub markdown CSS file in use to the always-dark version (matching the site using only a dark theme).

The site is currently always using the dark theme (as there is no code to switch the current theme), but the github-markdown-css package's default offering automatically switches between light and dark through the `@media (prefers-color-scheme)` rule.

For now, switch to the always-dark version of github-markdown-css and (since the single-theme versions do not use CSS variables) add custom CSS to make the background transparent again.

If the theme selector is ever implemented in the site, this will need to be revisited since there's no offering in the package for one CSS file that contains both light mode and dark mode using CSS variables and HTML classes/attributes to control the theme on the fly.

Tested to work by changing the site appearance setting in my browser (Firefox) to use light theme (instead of following the system theme).