### PR TITLE
Use npm ci

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Install deps
-        run: npm install
+        run: npm ci
       - name: Build site
         run: npm run build
       - name: Publish to Cloudflare Pages


### PR DESCRIPTION
Uses npm ci instead of install to get deps from package lock.