### PR TITLE
Use sorted=false when fetching versions

### DIFF
--- a/src/components/ProjectIndex.vue
+++ b/src/components/ProjectIndex.vue
@@ -40,7 +40,7 @@ import RepoDescription from "@/components/project/RepoDescription.vue";
 import { ref, onMounted } from "vue";
 
 const fetchLatestVersionByRegex = async (mavenPath: string, versionPattern: string) => {
-  const versions = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/` + mavenPath)
+  const versions = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/${mavenPath}?sorted=false`)
     .then(response => response.json())
     .then(res => res.versions as string[])
     .then(versions => versions.filter((version) => !versionPattern || version.match(versionPattern)).reverse())
@@ -53,9 +53,13 @@ const fetchLatestVersionByRegex = async (mavenPath: string, versionPattern: stri
 }
 
 const fetchLatestVersionByLatestAPI = async (mavenPath: string) => {
-  const latestVersion = await fetch(`https://maven.neoforged.net/api/maven/latest/version/releases/${mavenPath}`)
-            .then((res) => res.json())
-            .then((res) => res.version)
+  // Reposilite 3.5.27 added the `sorted` parameter to the /versions/endpoint, to return versions as listed in the maven-metadata.xml
+  // Use /versions/ endpoint instead of /latest/version/ until the `sorted` parameter is added for the latter
+  const latestVersion = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/${mavenPath}?sorted=false`)
+        .then(response => response.json())
+        .then(res => res.versions as string[])
+        .then(versions => versions.reverse())
+        .then(versions => versions[0])
             .catch((err) => {
               console.error("Failed to fetch versions:", err);
               return [];

--- a/src/components/ProjectIndex.vue
+++ b/src/components/ProjectIndex.vue
@@ -40,6 +40,7 @@ import RepoDescription from "@/components/project/RepoDescription.vue";
 import { ref, onMounted } from "vue";
 
 const fetchLatestVersionByRegex = async (mavenPath: string, versionPattern: string) => {
+  // Reposilite 3.5.27 adds a new query parameter 'sorted', with false meaning to avoid sorting versions (use raw order from maven-metadata.xml)
   const versions = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/${mavenPath}?sorted=false`)
     .then(response => response.json())
     .then(res => res.versions as string[])

--- a/src/components/ProjectIndex.vue
+++ b/src/components/ProjectIndex.vue
@@ -53,13 +53,11 @@ const fetchLatestVersionByRegex = async (mavenPath: string, versionPattern: stri
 }
 
 const fetchLatestVersionByLatestAPI = async (mavenPath: string) => {
-  // Reposilite 3.5.27 added the `sorted` parameter to the /versions/endpoint, to return versions as listed in the maven-metadata.xml
-  // Use /versions/ endpoint instead of /latest/version/ until the `sorted` parameter is added for the latter
-  const latestVersion = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/${mavenPath}?sorted=false`)
-        .then(response => response.json())
-        .then(res => res.versions as string[])
-        .then(versions => versions.reverse())
-        .then(versions => versions[0])
+  // Reposilite 3.5.28 adds a new query parameter 'sorted', with false meaning 
+  // to avoid sorting versions before taking the latest version (use raw order from maven-metadata.xml)
+  const latestVersion = await fetch(`https://maven.neoforged.net/api/maven/latest/version/releases/${mavenPath}?sorted=false`)
+            .then((res) => res.json())
+            .then((res) => res.version)
             .catch((err) => {
               console.error("Failed to fetch versions:", err);
               return [];

--- a/src/scripts/githubAPI.ts
+++ b/src/scripts/githubAPI.ts
@@ -6,7 +6,7 @@ async function getJson() {
         console.log(`Found repo info, using the cache.`)
         return res.default as object;
       })
-      .catch(err => {
+      .catch(_ => { // eslint-disable-line @typescript-eslint/no-unused-vars
         console.log(`Found no repo info json, using the API.`)
         return {} as object
       })

--- a/src/views/ProjectInfoView.vue
+++ b/src/views/ProjectInfoView.vue
@@ -256,7 +256,7 @@ export default {
         .then(res => res.slice(0, 10))
 
     // Special handling to remove the main logo from the readme html because it was destracting users away from the download dropdowns. Too much visual noise at bottom of page. 
-    const elementToRemoveRegex = /<p><img src="https:\/\/github\.com\/[\w/.]+\/\w*logo\w*\.(png|svg)" alt="[\w ]+">\<\/p>/i
+    const elementToRemoveRegex = /<p><img src="https:\/\/github\.com\/[\w/.]+\/\w*logo\w*\.(png|svg)" alt="[\w ]+"><\/p>/i
     const readmeContentPromise = marked(`https://github.com/${projectPath}/raw/${project.default_branch}/${readme.dir}`).parse(readme.readme)
     let readmeContent = typeof readmeContentPromise === "string" ? readmeContentPromise : await readmeContentPromise
     const extractedLogoElement = (readmeContent.match(elementToRemoveRegex) ?? [""])[0]
@@ -324,7 +324,7 @@ export default {
             .then(res => {
               this.displayChangelog = res.status == 200;
             })
-            .catch(err => this.displayChangelog = false);
+            .catch(_ => this.displayChangelog = false); // eslint-disable-line @typescript-eslint/no-unused-vars
       } else {
         this.displayChangelog = false;
       }

--- a/src/views/ProjectInfoView.vue
+++ b/src/views/ProjectInfoView.vue
@@ -208,7 +208,8 @@ export default {
 
     const projectPath =  'neoforged/' + repo;
 
-    const versions = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/` + mavenPath)
+    // Reposilite 3.5.27 adds a new query parameter 'sorted', with false meaning to list versions without sorting, as seen in the maven-metadata.xml
+    const versions = await fetch(`https://maven.neoforged.net/api/maven/versions/releases/${mavenPath}?sorted=false`)
         .then(response => response.json())
         .then(res => res.versions as string[])
         .then(versions => versions.reverse())


### PR DESCRIPTION
This PR fixes #21 by changing uses of the `/versions/` Reposilite API endpoint to use `sorted=false`, thus using the versions as listed in the `maven-metadata.xml` without any sorting applied.

~~Until dzikoysk/reposilite#2581 is implemented, uses of the `/latest/version/` API endpoint are replaced with the `/versions/` endpoint with `sorted=false`.~~ Replacement reverted.